### PR TITLE
chore: drop net9.0, target net10.0 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -1253,7 +1250,7 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
 - FF-1429 - Updated SonarAnalyzer.CSharp to 8.15.0.24505
 - FF-1429 - Updated SonarAnalyzer.CSharp to 8.16.0.25740
 
-## [1.1.0] - 2020-11-20
+## [1.1.0] 2020-11-20
 ### Changed
 - FF-1429 - Updated Microsoft.Extensions to 5.0.0
 - FF-1429 - Updated Microsoft.VisualStudio.Threading.Analyzers to 16.8.55
@@ -1261,11 +1258,11 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
 - FF-1429 - Updated Microsoft.VisualStudio.Threading.Analyzers to 16.8.51
 - Updated to .NET 5.0
 
-## [1.0.1] - 2020-10-26
+## [1.0.1] 2020-10-26
 ### Changed
 - Build process
 
-## [1.0.0] - 2020-10-24
+## [1.0.0] 2020-10-24
 ### Changed
 - Initial version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -14,6 +17,8 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Changed
 - Dotnet 10
 - SDK - Updated DotNet SDK to 10.0.302
+- Drop net9.0 support; target net10.0 only
+### Deprecated
 ### Removed
 ### Deployment Changes
 <!--
@@ -1248,7 +1253,7 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
 - FF-1429 - Updated SonarAnalyzer.CSharp to 8.15.0.24505
 - FF-1429 - Updated SonarAnalyzer.CSharp to 8.16.0.25740
 
-## [1.1.0] 2020-11-20
+## [1.1.0] - 2020-11-20
 ### Changed
 - FF-1429 - Updated Microsoft.Extensions to 5.0.0
 - FF-1429 - Updated Microsoft.VisualStudio.Threading.Analyzers to 16.8.55
@@ -1256,11 +1261,11 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
 - FF-1429 - Updated Microsoft.VisualStudio.Threading.Analyzers to 16.8.51
 - Updated to .NET 5.0
 
-## [1.0.1] 2020-10-26
+## [1.0.1] - 2020-10-26
 ### Changed
 - Build process
 
-## [1.0.0] 2020-10-24
+## [1.0.0] - 2020-10-24
 ### Changed
 - Initial version
 

--- a/src/Credfeto.Package.Push.Tests/Credfeto.Package.Push.Tests.csproj
+++ b/src/Credfeto.Package.Push.Tests/Credfeto.Package.Push.Tests.csproj
@@ -30,7 +30,7 @@
     <OutputType>Exe</OutputType>
     <RepositoryType>git</RepositoryType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Package.Push/Credfeto.Package.Push.csproj
+++ b/src/Credfeto.Package.Push/Credfeto.Package.Push.csproj
@@ -46,7 +46,7 @@
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <ToolCommandName>pushpackages</ToolCommandName>


### PR DESCRIPTION
## Summary

Drops net9.0 from the multi-targeted TargetFrameworks in this repository so the affected projects target net10.0 exclusively, per the approved implementation plan on #272.

### Files to change (next commit on this branch)
- src/Credfeto.Package.Push.Tests/Credfeto.Package.Push.Tests.csproj: change TargetFrameworks net9.0;net10.0 to a single TargetFramework net10.0
- src/Credfeto.Package.Push/Credfeto.Package.Push.csproj: change TargetFrameworks net9.0;net10.0 to a single TargetFramework net10.0

No net9.0-specific conditions, #if NET9_0 (non-_OR_GREATER) guards, global.json pins, or CI workflow pins were found elsewhere in the repo.

This PR currently contains only a placeholder CHANGELOG entry to reserve the work; the .csproj edits land in a follow-up commit.

Closes #272